### PR TITLE
Feat/zema 1847/card data and proxy

### DIFF
--- a/lib/m2y_fast/configuration/configuration.rb
+++ b/lib/m2y_fast/configuration/configuration.rb
@@ -3,7 +3,7 @@
 module M2yFast
   class Configuration
 
-    attr_writer :username, :password, :cnpj, :proxy, :env, :wsdl
+    attr_writer :username, :password, :cnpj, :proxy, :env, :wsdl, :savon_client
 
     def initialize #:nodoc:
       @username = nil
@@ -12,6 +12,7 @@ module M2yFast
       @proxy = nil
       @env = nil
       @wsdl = nil
+      @savon_client = nil
     end
 
     def username
@@ -36,6 +37,18 @@ module M2yFast
 
     def wsdl
       @wsdl
+    end
+
+    def savon_client
+      @savon_client ||= Savon.client(
+        wsdl: M2yFast.configuration.wsdl,
+        log: true,
+        proxy: M2yFast.configuration.proxy,
+        log_level: M2yFast.configuration.production? ? :info : :debug,
+        pretty_print_xml: true,
+        open_timeout: 30,
+        read_timeout: 30
+      )
     end
 
     def production?

--- a/lib/m2y_fast/constants/constants.rb
+++ b/lib/m2y_fast/constants/constants.rb
@@ -1,6 +1,4 @@
 module M2yFast
-  WSDL_HMG = "https://sistemashomol.fastpays.com.br/Zema/WSGServService?wsdl"
-  WSDL_PRD = "https://secure.fastpays.com.br/Zema/WSGServService?wsdl"
   XML_VERSION = 1
   ISSUER = 36
   PRODUCT = 88

--- a/lib/m2y_fast/modules/base.rb
+++ b/lib/m2y_fast/modules/base.rb
@@ -16,6 +16,37 @@ module M2yFast
       )
     end
 
+    def self.fixie
+      URI.parse M2yFast.configuration.proxy
+    end
+
+    def self.base_headers
+      headers = {}
+      headers['Content-Type'] = 'application/json'
+      headers
+    end
+
+    def self.soap_post(body)
+      url = M2yFast.configuration.wsdl.gsub('?wsdl', '')
+      xml_headers = {}
+      xml_headers['Content-Type'] = 'text/xml'
+      xml_headers['charset'] = 'utf-8'
+      post(url, body, xml_headers)
+    end
+
+    def self.post(url, body, headers = nil)
+      if headers.nil?
+        headers = base_headers
+      end
+      puts "Sending POST request to URL: #{url}"
+      puts body
+      HTTParty.post(url, headers: headers, body: body,
+                    http_proxyaddr: fixie.host,
+                    http_proxyport: fixie.port,
+                    http_proxyuser: fixie.user,
+                    http_proxypass: fixie.password)
+    end
+
     def self.trace
       rand(100000..999999)
     end

--- a/lib/m2y_fast/modules/card.rb
+++ b/lib/m2y_fast/modules/card.rb
@@ -1,111 +1,106 @@
 module M2yFast
-
-  require "savon"
-  require 'digest/md5'
-
-  class Card
-
-    def self.get_client
-      Savon.client(
-        wsdl: M2yFast.configuration.wsdl,
-        log: true,
-        proxy: M2yFast.configuration.proxy,
-        log_level: M2yFast.configuration.production? ? :info : :debug,
-        pretty_print_xml: true,
-        open_timeout: 15,
-        read_timeout: 15
-      )
-    end
+  class Card < Base
 
     def self.request_card(body)
-      client = get_client
       body[:registration] = (Time.now.to_i.to_s + Random.rand(99).to_s).to_i
       xml = XmlBuilder.request_card_xml(body)
-      response = client.call(:cadastro_cartao_geral, xml: xml)
+      response = M2yFast.configuration.savon_client.call(:cadastro_cartao_geral, xml: xml)
       XmlResponseParser.request_card_response(response.body, body)
     end
 
     def self.register_password(card_id, encrypted_password)
-      client = get_client
       xml = XmlBuilder.register_password_xml(card_id, encrypted_password, trace)
-      response = client.call(:cadastra_senha_cert, xml: xml)
+      response = M2yFast.configuration.savon_client.call(:cadastra_senha_cert, xml: xml)
       XmlResponseParser.register_password_response(response.body)
     end
 
     def self.block_card(card_id)
-      client = get_client
       xml = XmlBuilder.block_card_xml(card_id, trace)
-      response = client.call(:bloqueio_cartao, xml: xml)
+      response = M2yFast.configuration.savon_client.call(:bloqueio_cartao, xml: xml)
       XmlResponseParser.block_card_response(response.body)
     end
 
     def self.validate_password(card_id, password)
-      client = get_client
       xml = XmlBuilder.validate_password_xml(card_id, password, trace)
-      response = client.call(:verifica_senha, xml: xml)
+      response = M2yFast.configuration.savon_client.call(:verifica_senha, xml: xml)
       XmlResponseParser.validate_password_response(response.body)
     end
 
     def self.update_password(body)
-      client = get_client
       body[:trace] = trace
       xml = XmlBuilder.update_password_xml(body)
-      response = client.call(:alterar_senha, xml: xml)
+      response = M2yFast.configuration.savon_client.call(:alterar_senha, xml: xml)
       XmlResponseParser.update_password_response(response.body)
     end
 
     def self.activate_card(card_id)
-      client = get_client
       xml = XmlBuilder.activate_card_xml(card_id, trace)
-      response = client.call(:ativacao_cartao, xml: xml)
+      response = M2yFast.configuration.savon_client.call(:ativacao_cartao, xml: xml)
       XmlResponseParser.activate_card_response(response.body)
     end
 
     def self.check_card(card_id)
-      client = get_client
       xml = XmlBuilder.check_card_xml(card_id, trace)
-      response = client.call(:retorna_status, xml: xml)
+      response = M2yFast.configuration.savon_client.call(:retorna_status, xml: xml)
       XmlResponseParser.check_card_response(response.body)
     end
 
     def self.check_cvv(body)
-      client = get_client
       xml = XmlBuilder.check_cvv_xml(body, trace)
-      response = client.call(:verifica_cvv_cert, xml: xml)
+      response = M2yFast.configuration.savon_client.call(:verifica_cvv_cert, xml: xml)
       XmlResponseParser.check_cvv_response(response.body)
     end
 
     def self.card_limit(card_id)
-      client = get_client
       xml = XmlBuilder.card_limit_xml(card_id)
-      response = client.call(:consulta_disponivel, xml: xml)
+      response = M2yFast.configuration.savon_client.call(:consulta_disponivel, xml: xml)
       XmlResponseParser.card_limit_response(response.body)
     end
 
     def self.recall_password(card_id)
-      client = get_client
       xml = XmlBuilder.recall_password_xml(card_id, trace)
-      response = client.call(:retorna_pin_cert, xml: xml)
+      response = M2yFast.configuration.savon_client.call(:retorna_pin_cert, xml: xml)
       XmlResponseParser.recall_password_response(response.body)
     end
 
     def self.update_limit(body)
-      client = get_client
       xml = XmlBuilder.update_limit_xml(body)
-      response = client.call(:alterar_limite, xml: xml)
+      response = M2yFast.configuration.savon_client.call(:alterar_limite, xml: xml)
       XmlResponseParser.update_limit_response(response.body)
     end
 
     # melhor_dia_para_compras
     def self.best_day_for_shopping(card_id)
-      client = get_client
       xml = XmlBuilder.best_day_for_shopping_xml(card_id)
-      response = client.call(:melhor_dia_para_compras, xml: xml)
+      response = M2yFast.configuration.savon_client.call(:melhor_dia_para_compras, xml: xml)
       XmlResponseParser.best_day_for_shopping_response(response.body)
     end
 
-    def self.trace
-      rand(100000..999999)
+    # This method makes two calls to the FAST API in order to reduce any overhead in processing
+    # retorna_status + consulta_disponivel
+    def self.card_data(card_id)
+      status_response = soap_post(XmlBuilder.check_card_xml(card_id, trace))
+      partial_response = status_response.body.split("<return>").last.split("</return>").first
+      partial_return_code = partial_response.split("&lt;codigo_retorno&gt;").last.split("&lt;/codigo_retorno&gt;").first
+      partial_status = partial_response.split("&lt;desc_status&gt;").last.split("&lt;/desc_status&gt;").first.to_s.upcase
+      # First request returns error
+      if partial_return_code != '00'
+        {
+          error: true,
+          code: partial_return_code.to_i
+        }
+      # If card is not active, there is no need to check card limit
+      elsif partial_status.in?(['CARTAO APROVADO',
+                                'ENVIADO PARA EMBOSSADORA',
+                                'ENVIADO ARQ. PARA DELIVERY',
+                                'ENVIADO ARQ PARA DELIVERY',
+                                'EMBOSSADO',
+                                'ENVIADO AO PORTADOR'])
+        XmlResponseParser.card_data_response(status_response, nil)
+      else
+        limit_response = soap_post(XmlBuilder.card_limit_xml(card_id))
+        XmlResponseParser.card_data_response(status_response, limit_response)
+      end
     end
   end
 end

--- a/lib/m2y_fast/modules/cardholder.rb
+++ b/lib/m2y_fast/modules/cardholder.rb
@@ -2,33 +2,29 @@ module M2yFast
   class Cardholder < Base
     # consulta_portador
     def self.get_cardholder(body)
-      client = get_client
       xml = CardholderXmlBuilder.get_cardholder_xml(body)
-      response = client.call(:consulta_portador, xml: xml)
+      response = M2yFast.configuration.savon_client.call(:consulta_portador, xml: xml)
       full_response(CardholderXmlResponseParser.get_cardholder_response(response.body), xml, response.body)
     end
 
     # dados_gral_portador
     def self.get_user_registration(card_id)
-      client = get_client
       xml = CardholderXmlBuilder.get_user_registration_xml(card_id)
-      response = client.call(:dados_gral_portador, xml: xml)
+      response = M2yFast.configuration.savon_client.call(:dados_gral_portador, xml: xml)
       full_response(CardholderXmlResponseParser.get_user_registration_response(response.body), xml, response.body)
     end
 
     # alteracao_portador2
     def self.update_user_registration(body)
-      client = get_client
       xml = CardholderXmlBuilder.update_user_registration_xml(body)
-      response = client.call(:alteracao_portador2, xml: xml)
+      response = M2yFast.configuration.savon_client.call(:alteracao_portador2, xml: xml)
       full_response(CardholderXmlResponseParser.update_user_registration_response(response.body), xml, response.body)
     end
 
     # cartoes_cpf
     def self.account_for_document(cpf)
-      client = get_client
       xml = CardholderXmlBuilder.account_for_document_xml(cpf)
-      response = client.call(:cartoes_cpf, xml: xml)
+      response = M2yFast.configuration.savon_client.call(:cartoes_cpf, xml: xml)
       full_response(CardholderXmlResponseParser.account_for_document_response(response.body), xml, response.body)
     end
   end

--- a/lib/m2y_fast/modules/limit.rb
+++ b/lib/m2y_fast/modules/limit.rb
@@ -2,9 +2,8 @@ module M2yFast
   class Limit < Base
     # cadastra um valor de crédito para o user
     def self.generate_authorization(card_id, value)
-      client = get_client
       xml = LimitXmlBuilder.generate_authorization_xml(card_id, value, trace)
-      response = client.call(:gera_autorizacao, xml: xml)
+      response = M2yFast.configuration.savon_client.call(:gera_autorizacao, xml: xml)
       full_response(LimitXmlResponseParser.generate_authorization_response(response.body), xml, response.body)
     end
   end

--- a/lib/m2y_fast/modules/statement.rb
+++ b/lib/m2y_fast/modules/statement.rb
@@ -3,35 +3,31 @@ module M2yFast
     # consulta_faturas
     # Obs: paginacao foi desabilitada pela Fast
     def self.get_statement(fast_account)
-      client = get_client
       xml = StatementXmlBuilder.get_statement_xml(fast_account)
-      response = client.call(:consulta_faturas, xml: xml)
+      response = M2yFast.configuration.savon_client.call(:consulta_faturas, xml: xml)
       full_response(StatementXmlResponseParser.get_statement_response(response.body), xml, response.body)
     end
 
     # consulta_fatura_aberta
     # Obs: paginacao foi desabilitada pela Fast
     def self.get_current_invoice(fast_account)
-      client = get_client
       xml = StatementXmlBuilder.get_current_invoice_xml(fast_account)
-      response = client.call(:consulta_fatura_aberta, xml: xml)
+      response = M2yFast.configuration.savon_client.call(:consulta_fatura_aberta, xml: xml)
       full_response(StatementXmlResponseParser.get_current_invoice_response(response.body), xml, response.body)
     end
 
     # consulta_detalhe_fatura
     # Obs: paginacao foi desabilitada pela Fast
     def self.get_statement_detail(fast_account, period)
-      client = get_client
       xml = StatementXmlBuilder.get_statement_detail_xml(fast_account, period)
-      response = client.call(:consulta_detalhe_fatura, xml: xml)
+      response = M2yFast.configuration.savon_client.call(:consulta_detalhe_fatura, xml: xml)
       full_response(StatementXmlResponseParser.get_statement_detail_xml_response(response.body), xml, response.body)
     end
 
     # gera_boleto
     def self.get_statement_billet(fast_account, period)
-      client = get_client
       xml = StatementXmlBuilder.get_statement_billet_xml(fast_account, period)
-      response = client.call(:gera_boleto, xml: xml)
+      response = M2yFast.configuration.savon_client.call(:gera_boleto, xml: xml)
       full_response(StatementXmlResponseParser.get_statement_billet_xml_response(response.body), xml, response.body)
     end
   end

--- a/lib/m2y_fast/version.rb
+++ b/lib/m2y_fast/version.rb
@@ -1,3 +1,3 @@
 module M2yFast
-  VERSION = "0.0.1"
+  VERSION = "1.0.0"
 end

--- a/m2y_fast.gemspec
+++ b/m2y_fast.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_runtime_dependency "httparty"
   spec.add_runtime_dependency "openssl"
   spec.add_runtime_dependency "savon"
   spec.add_runtime_dependency 'activesupport', '~> 6.1.3.1'


### PR DESCRIPTION
- Adiciona client Savon padrão para evitar a inicialização em todas as requests
- Altera todos os métodos para utilizar o client padrão
- Adiciona método para POST com HTTParty, que é mais rápido que o post com Savon
- Cria método card_data, que faz chamadas para retorna_status e consulta_disponivel, evitando processamentos desnecessários, de forma a aumentar a velocidade de resposta do endpoint